### PR TITLE
implemented ability to set new theme based on previous theme state

### DIFF
--- a/src/theme-toggler.tsx
+++ b/src/theme-toggler.tsx
@@ -19,9 +19,20 @@ export const useTheme = () => {
     }
   }, [])
 
-  const toggleTheme = useCallback((theme: string) => {
-    window.__setPreferredTheme(theme)
-  }, [])
+  const toggleTheme = useCallback(
+    (theme: string | ((prevTheme: string | null) => string)) => {
+      if (typeof theme === 'string') {
+        window.__setPreferredTheme(theme);
+      } else if (typeof theme === 'function') {
+        setCurrentTheme((prevTheme) => {
+          const newTheme = theme(prevTheme);
+          window.__setPreferredTheme(newTheme);
+          return newTheme;
+        });
+      }
+    },
+    []
+  );
 
   return [currentTheme, toggleTheme] as [
     typeof currentTheme,


### PR DESCRIPTION
Currently you can't set the theme based on the previous theme state. This makes it difficult to **toggle** darkmode. This change allows you to pass a function into `toggleTheme()` that takes in the latest theme state as a parameter, and returns what the next theme state should be. This is the same functionality as the `useState()` hook.